### PR TITLE
[리팩토링] AuditingFields 의 잘못 표현된 부분 개선

### DIFF
--- a/src/main/java/com/fastcampus/projectboard/domain/AuditingFields.java
+++ b/src/main/java/com/fastcampus/projectboard/domain/AuditingFields.java
@@ -23,19 +23,19 @@ public abstract class AuditingFields {
     @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
     @CreatedDate
     @Column(nullable = false, updatable = false)
-    private LocalDateTime createdAt; // 생성일시
+    protected LocalDateTime createdAt; // 생성일시
 
     @CreatedBy
     @Column(nullable = false, updatable = false, length = 100)
-    private String createdBy; // 생성자
+    protected String createdBy; // 생성자
 
     @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
     @LastModifiedDate
     @Column(nullable = false)
-    private LocalDateTime modifiedAt; // 수정일시
+    protected LocalDateTime modifiedAt; // 수정일시
 
     @LastModifiedBy
     @Column(nullable = false, length = 100)
-    private String modifiedBy; // 수정자
+    protected String modifiedBy; // 수정자
 
 }


### PR DESCRIPTION
AuditingFields 클래스는 추상 클래스이고, 각 필드는 상속 받는 자식 엔티티에서 접근 및 수정이 가능해야 한다. 따라서 접근 제어자를 protected로 했어야 했는데, 이 접근 제어를 초기 설계에서 지나치게 폐쇄적으로 작성했다.

위 내용이 당장은 비즈니스 요구사항이 없어 문제가 되지 않았으나,
이제 #74 를 작업하면서, 회원 도메인에서 인증이 없는 상태의 회원 정보를 저장하기 위해서 작성자(createdBy), 수정자(modifiedBy)를 엔티티가 직접 작성해야 하는 요구사항이 생길 것이므로 이것이 가능하게끔 접근 제어자를 제대로 수정해주도록 한다.